### PR TITLE
recognize strings in NMODL, fix comment misidentification

### DIFF
--- a/syntaxes/NMODL.tmLanguage
+++ b/syntaxes/NMODL.tmLanguage
@@ -16,7 +16,26 @@
 			<string>"(?:[^"\\]|\\.)*"</string>
 			<key>name</key>
 			<string>string.quoted.double</string>
-		</dict>	
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>entity.represented</string>
+			<key>match</key>
+			<string>\b(REPRESENTS)\b\s+([^:\s]+:[^:\s]+)</string>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.other.nmodl</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>entity.identifier</string>
+				</dict>
+			</dict>
+		</dict>
 		<dict>
 			<key>match</key>
 			<string>(\:).*$\n?</string>

--- a/syntaxes/NMODL.tmLanguage
+++ b/syntaxes/NMODL.tmLanguage
@@ -13,6 +13,12 @@
 	<array>
 		<dict>
 			<key>match</key>
+			<string>"(?:[^"\\]|\\.)*"</string>
+			<key>name</key>
+			<string>string.quoted.double</string>
+		</dict>	
+		<dict>
+			<key>match</key>
 			<string>(\:).*$\n?</string>
 			<key>name</key>
 			<string>comment.line.nmodl</string>


### PR DESCRIPTION
NMODL's `printf` function works with strings. We must explicitly recognize them before looking for comments or a colon inside the string will be misinterpreted as marking the beginning of a comment.

e.g.
```
printf("t: %g\n", t)  : this is a comment
```

This also fixes `REPRESENTS` by recognizing it as an nmodl entity and recognizing that an ontology identifier follows it and that it should not misinterpret the colon in the identifier as starting a comment. This resolves #2